### PR TITLE
Staging

### DIFF
--- a/app/Livewire/UserList.php
+++ b/app/Livewire/UserList.php
@@ -3,6 +3,7 @@
 namespace App\Livewire;
 
 use App\Models\User;
+use Illuminate\View\View;
 use Livewire\Component;
 use Livewire\WithPagination;
 
@@ -10,8 +11,14 @@ class UserList extends Component
 {
     use WithPagination;
 
-    public function render()
+
+    public function placeholder(): View
     {
+        return view('loading');
+    }
+    public function render(): View
+    {
+        sleep(3);
         $users = User::latest()->paginate(5);
         return view('livewire.user-list', ['users' => $users, 'total' => $users->total()]);
     }

--- a/resources/views/loading.blade.php
+++ b/resources/views/loading.blade.php
@@ -1,7 +1,76 @@
 <div>
-    <div class="d-flex justify-content-center my-5">
-        <div class="spinner-border" role="status">
-          <span class="visually-hidden">Loading...</span>
-        </div>
-      </div>
+    <div class="my-3">
+        <h1 class="placeholder-glow">
+            <span class="placeholder col-2"></span>
+        </h1>
+    </div>
+    <ul class="list-group list-group">
+        <li class="list-group-item ">
+            <div class="ms-2 me-auto">
+                <div class="placeholder-glow d-inline">
+                    <span class="placeholder col-4 bg-secondary"></span>
+                </div>
+                <span class="btn btn-primary disabled placeholder col-1 rounded-pill d-inline"
+                    style="float: right"></span>
+                <div class="placeholder-glow d-block">
+                    <span class="placeholder col-6 bg-secondary"></span>
+                </div>
+            </div>
+        </li>
+        <li class="list-group-item ">
+            <div class="ms-2 me-auto">
+                <div class="placeholder-glow d-inline">
+                    <span class="placeholder col-4 bg-secondary"></span>
+                </div>
+                <span class="btn btn-primary disabled placeholder col-1 rounded-pill d-inline"
+                    style="float: right"></span>
+                <div class="placeholder-glow d-block">
+                    <span class="placeholder col-6 bg-secondary"></span>
+                </div>
+            </div>
+        </li>
+        <li class="list-group-item ">
+            <div class="ms-2 me-auto">
+                <div class="placeholder-glow d-inline">
+                    <span class="placeholder col-4 bg-secondary"></span>
+                </div>
+                <span class="btn btn-primary disabled placeholder col-1 rounded-pill d-inline"
+                    style="float: right"></span>
+                <div class="placeholder-glow d-block">
+                    <span class="placeholder col-6 bg-secondary"></span>
+                </div>
+            </div>
+        </li>
+        <li class="list-group-item ">
+            <div class="ms-2 me-auto">
+                <div class="placeholder-glow d-inline">
+                    <span class="placeholder col-4 bg-secondary"></span>
+                </div>
+                <span class="btn btn-primary disabled placeholder col-1 rounded-pill d-inline"
+                    style="float: right"></span>
+                <div class="placeholder-glow d-block">
+                    <span class="placeholder col-6 bg-secondary"></span>
+                </div>
+            </div>
+        </li>
+        <li class="list-group-item ">
+            <div class="ms-2 me-auto">
+                <div class="placeholder-glow d-inline">
+                    <span class="placeholder col-4 bg-secondary"></span>
+                </div>
+                <span class="btn btn-primary disabled placeholder col-1 rounded-pill d-inline"
+                    style="float: right"></span>
+                <div class="placeholder-glow d-block">
+                    <span class="placeholder col-6 bg-secondary"></span>
+                </div>
+            </div>
+        </li>
+    </ul>
+    <div class="placeholder-glow mt-2 d-inline">
+        <span class="placeholder col-2 bg-secondary"></span>
+    </div>
+    <div class="placeholder-glow d-inline">
+        <span class="placeholder placeholder-lg col-4 bg-secondary mt-2" style="float: right"></span>
+    </div>
+
 </div>

--- a/resources/views/loading.blade.php
+++ b/resources/views/loading.blade.php
@@ -1,0 +1,7 @@
+<div>
+    <div class="d-flex justify-content-center my-5">
+        <div class="spinner-border" role="status">
+          <span class="visually-hidden">Loading...</span>
+        </div>
+      </div>
+</div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -16,7 +16,8 @@
 
 <body class="font-sans antialiased dark:bg-black dark:text-white/50">
     <div class="container">
-        <livewire:user-list />
+        <livewire:user-list lazy />
+        {{-- @livewire('user-list', ['lazy' => true]) --}}
     </div>
 </body>
 


### PR DESCRIPTION
By default, Livewire will insert an empty <div></div> for your component before it is fully loaded. As the component will initially be invisible to users, it can be jarring when the component suddenly appears on the page.

To signal to your users that the component is being loaded, you can define a placeholder() method to render any kind of placeholder HTML you like, including loading spinners and skeleton placeholders.